### PR TITLE
[UPDATE]Project gradle,dependencies,dependency version references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,60 @@
 buildscript {
+    ext.versions = [
+            'compileSdk'                : 28,
+            'minSdk'                    : 14,
+            'targetSdk'                 : 28,
+            'versionName'               : VERSION_NAME,
+            'versionCode'               : VERSION_CODE,
+
+            'appcompat'                 : '28.0.0-rc02',
+            'retrofitMoshi'             : retrofitVersion,
+            'retrofitVersion'           : retrofitVersion,
+            'retrofitRxAdapter'         : '2.4.0',
+            'okhttpLogging'             : '3.10.0',
+            'okhttpVersion'             : okhttpVersion,
+            'okhttpMockServer'          : okhttpVersion,
+            'timber'                    : '4.6.1',
+            'rxjava'                    : '2.1.12',
+            'rxandroid'                 : '2.0.2',
+            'scribejavaApis'            : '5.3.0',
+            'scribejavaHttpClientOkHttp': '5.3.0',
+            'dexcountGradle'            : '0.6.4',
+            'benmanesGradle'            : '0.13.0',
+            'codeQuality'               : '0.10.0',
+
+            'junit'                     : '4.12',
+            'testRules'                 : '1.0.2',
+            'testRunner'                : '1.0.2',
+            'mochitoCore'               : '2.21.0',
+            'mochitoAndroid'            : '2.21.0',
+            'mochitoKotlin'             : '1.5.0',
+            'robolectric'               : '4.0-alpha-4-SNAPSHOT',
+
+            'kotlin'                    : kotlinVersion,
+            'kotlinStdlib'              : kotlinVersion,
+            'kotlinReflect'             : kotlinVersion,
+            'gradle'                    : '3.1.4'
+    ]
+    ext.names = [
+            'applicationId'            : 'com.andretietz.retroauth.demo',
+            'testInstrumentationRunner': 'android.support.test.runner.AndroidJUnitRunner'
+    ]
+
+
     repositories {
         jcenter()
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
     dependencies {
         // android plugin
-        classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.4'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
-        classpath "com.vanniktech:gradle-code-quality-tools-plugin:0.10.0"
+        classpath "com.android.tools.build:gradle:${versions.gradle}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+        classpath "com.getkeepsafe.dexcount:dexcount-gradle-plugin:${versions.dexcountGradle}"
+        classpath "com.github.ben-manes:gradle-versions-plugin:${versions.benmanesGradle}"
+        classpath "com.vanniktech:gradle-code-quality-tools-plugin:${versions.codeQuality}"
     }
 }
 
@@ -21,6 +64,7 @@ allprojects {
         google()
         mavenCentral()
         jcenter()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
             'versionName'               : VERSION_NAME,
             'versionCode'               : VERSION_CODE,
 
-            'appcompat'                 : '28.0.0-rc02',
+            'appcompat'                 : '27.1.1',
             'retrofitMoshi'             : retrofitVersion,
             'retrofitVersion'           : retrofitVersion,
             'retrofitRxAdapter'         : '2.4.0',

--- a/demoandroid/build.gradle
+++ b/demoandroid/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion versions.compileSdk
 
     defaultConfig {
-        applicationId "com.andretietz.retroauth.demo"
-        minSdkVersion 14
-        targetSdkVersion 27
-        versionCode 1
-        versionName "1.0.0"
+        applicationId names.applicationId
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
+        versionCode versions.versionCode as Integer
+        versionName versions.versionName
     }
     buildTypes {
         release {
@@ -29,15 +29,15 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.0'
-    implementation "com.squareup.retrofit2:converter-moshi:2.3.0"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:2.3.0"
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
-    implementation 'com.jakewharton.timber:timber:4.6.1'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
-    implementation 'com.github.scribejava:scribejava-apis:5.3.0'
-    implementation 'com.github.scribejava:scribejava-httpclient-okhttp:5.3.0'
+    implementation "com.android.support:appcompat-v7:${versions.appcompat}"
+    implementation "com.squareup.retrofit2:converter-moshi:${versions.retrofitMoshi}"
+    implementation "com.squareup.okhttp3:okhttp:${versions.okhttpVersion}"
+    implementation "com.squareup.retrofit2:adapter-rxjava2:${versions.retrofitRxAdapter}"
+    implementation "com.squareup.okhttp3:logging-interceptor:${versions.okhttpLogging}"
+    implementation "com.jakewharton.timber:timber:${versions.timber}"
+    implementation "io.reactivex.rxjava2:rxandroid:${versions.rxandroid}"
+    implementation "com.github.scribejava:scribejava-apis:${versions.scribejavaApis}"
+    implementation "com.github.scribejava:scribejava-httpclient-okhttp:${versions.scribejavaHttpClientOkHttp}"
 
     implementation project(':retroauth-android')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,11 @@
 # Release Settings
-kotlinVersion=1.2.30
+kotlinVersion=1.2.61
 okhttpVersion=3.10.0
 retrofitVersion=2.3.0
 
 GROUP=com.andretietz.retroauth
 VERSION_NAME=3.0.0-beta6-SNAPSHOT
+VERSION_CODE=1
 POM_DESCRIPTION=A library build on top of retrofit, for simple handling of authenticated requests.
 POM_URL=https://github.com/andretietz/retroauth
 POM_SCM_URL=https://github.com/andretietz/retroauth

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/retroauth-android/build.gradle
+++ b/retroauth-android/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'kotlin-android'
 
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion versions.compileSdk
 
     defaultConfig {
-        minSdkVersion 14
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        targetSdkVersion 23
-        versionCode 1
-        versionName VERSION_NAME
+        minSdkVersion versions.minSdk
+        testInstrumentationRunner names.testInstrumentationRunner
+        targetSdkVersion  versions.targetSdk
+        versionCode versions.versionCode as Integer
+        versionName versions.versionName
     }
     buildTypes {
         release {
@@ -45,16 +45,16 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:23.0.0'
+    implementation "com.android.support:appcompat-v7:${versions.appcompat}"
     api project(':retroauth')
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:3.6"
-    testImplementation 'org.mockito:mockito-core:2.13.0'
+    testImplementation "junit:junit:${versions.junit}"
+    testImplementation "org.robolectric:robolectric:${versions.robolectric}"
+    testImplementation "org.mockito:mockito-core:${versions.mochitoCore}"
 
-    androidTestImplementation 'org.mockito:mockito-android:2.17.0'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation "org.mockito:mockito-android:${versions.mochitoAndroid}"
+    androidTestImplementation "com.android.support.test:runner:${versions.testRunner}"
+    androidTestImplementation "com.android.support.test:rules:${versions.testRules}"
 
 }
 apply plugin: 'com.getkeepsafe.dexcount'

--- a/retroauth/build.gradle
+++ b/retroauth/build.gradle
@@ -3,16 +3,16 @@ apply plugin: 'java-library'
 
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    api "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlinStdlib}"
+    api "com.squareup.retrofit2:retrofit:${versions.retrofitVersion}"
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation "io.reactivex.rxjava2:rxjava:2.1.12"
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
-    testImplementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
-    testImplementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
-    testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
+    testImplementation "junit:junit:${versions.junit}"
+    testImplementation "io.reactivex.rxjava2:rxjava:${versions.rxjava}"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlinReflect}"
+    testImplementation "com.squareup.okhttp3:mockwebserver:${versions.okhttpMockServer}"
+    testImplementation "com.squareup.retrofit2:converter-moshi:${versions.retrofitMoshi}"
+    testImplementation "com.squareup.retrofit2:adapter-rxjava2:${versions.retrofitRxAdapter}"
+    testImplementation "com.nhaarman:mockito-kotlin:${versions.mochitoKotlin}"
 }
 
 apply from: rootProject.file('gradle/publish.gradle')


### PR DESCRIPTION
I use this lib for some cases, however, in order to compile the whole things there're problems for lib associated dependencies, even android related stuffs.
- gradle to stable 3.1.4
- kotlin to 1.2.61
- retrofit, rx, okhttp ....
- Move all versions of dependencies to root build.gradle which is general thought.