### PR TITLE
[BUG]AccountAuthenticatorTest.kt has unsafe null-point.

### DIFF
--- a/retroauth-android/src/test/java/com/andretietz/retroauth/AccountAuthenticatorTest.kt
+++ b/retroauth-android/src/test/java/com/andretietz/retroauth/AccountAuthenticatorTest.kt
@@ -46,8 +46,8 @@ class AccountAuthenticatorTest {
     assertEquals(
       response,
       requireNotNull(intent).getParcelableExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE))
-    assertEquals("accountType", intent.getStringExtra(AccountManager.KEY_ACCOUNT_TYPE))
-    assertEquals("tokenType", intent.getStringExtra(AccountAuthenticator.KEY_TOKEN_TYPE))
+    assertEquals("accountType", intent?.getStringExtra(AccountManager.KEY_ACCOUNT_TYPE))
+    assertEquals("tokenType", intent?.getStringExtra(AccountAuthenticator.KEY_TOKEN_TYPE))
   }
 
   @Test
@@ -63,9 +63,9 @@ class AccountAuthenticatorTest {
     assertEquals(
       response,
       requireNotNull(intent).getParcelableExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE))
-    assertEquals("accountType", intent.getStringExtra(AccountManager.KEY_ACCOUNT_TYPE))
-    assertEquals("tokenType", intent.getStringExtra(AccountAuthenticator.KEY_TOKEN_TYPE))
-    assertEquals("accountName", intent.getStringExtra(AccountManager.KEY_ACCOUNT_NAME))
+    assertEquals("accountType", intent?.getStringExtra(AccountManager.KEY_ACCOUNT_TYPE))
+    assertEquals("tokenType", intent?.getStringExtra(AccountAuthenticator.KEY_TOKEN_TYPE))
+    assertEquals("accountName", intent?.getStringExtra(AccountManager.KEY_ACCOUNT_NAME))
   }
 
   @Test


### PR DESCRIPTION
All references of `intent` should be nullable which means the `?` must be used while being used, otherwise 
the tests could be broken down unpredictable.

> Unsafe use of a nullable receiver of type Intent?

Kotlin-plugin: 1.2.61
AS Gradle: 3.3.0