### PR TITLE
Prevent crash when user cancels login

### DIFF
--- a/demoandroid/src/main/java/com/andretietz/retroauth/demo/LoginActivity.kt
+++ b/demoandroid/src/main/java/com/andretietz/retroauth/demo/LoginActivity.kt
@@ -40,7 +40,6 @@ class LoginActivity : AuthenticationActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_login)
-    Timber.plant(Timber.DebugTree())
 
     webView.loadUrl(helper.authorizationUrl)
     @Suppress("UsePropertyAccessSyntax")

--- a/demoandroid/src/main/java/com/andretietz/retroauth/demo/MainActivity.kt
+++ b/demoandroid/src/main/java/com/andretietz/retroauth/demo/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.andretietz.retroauth.demo
 
+import android.accounts.Account
 import android.os.Build
 import android.os.Bundle
 import android.webkit.CookieManager
@@ -13,6 +14,7 @@ import com.andretietz.retroauth.RetroauthAndroid
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_main.buttonInvalidateToken
+import kotlinx.android.synthetic.main.activity_main.buttonLogin
 import kotlinx.android.synthetic.main.activity_main.buttonLogout
 import kotlinx.android.synthetic.main.activity_main.buttonRequestEmail
 import kotlinx.android.synthetic.main.activity_main.buttonSwitch
@@ -118,6 +120,18 @@ class MainActivity : AppCompatActivity() {
       } else {
         cookieManager.removeAllCookies(null)
       }
+    }
+
+    buttonLogin.setOnClickListener {
+      ownerManager.createOwner(provider.ownerType, provider.credentialType, object : Callback<Account> {
+        override fun onResult(result: Account) {
+          Timber.d("Logged in: $result")
+        }
+
+        override fun onError(error: Throwable) {
+          showError(error)
+        }
+      })
     }
   }
 

--- a/demoandroid/src/main/res/layout/activity_main.xml
+++ b/demoandroid/src/main/res/layout/activity_main.xml
@@ -34,4 +34,10 @@
         android:layout_height="wrap_content"
         android:text="Logout"/>
 
+    <Button
+        android:id="@+id/buttonLogin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Manual login"/>
+
 </LinearLayout>

--- a/retroauth-android/src/main/java/com/andretietz/retroauth/AndroidOwnerStorage.kt
+++ b/retroauth-android/src/main/java/com/andretietz/retroauth/AndroidOwnerStorage.kt
@@ -44,7 +44,6 @@ class AndroidOwnerStorage constructor(
   private val executor by lazy { Executors.newSingleThreadExecutor() }
   private val accountManager by lazy { AccountManager.get(application) }
 
-  @Throws(AuthenticationCanceledException::class)
   override fun createOwner(
     ownerType: String,
     credentialType: AndroidCredentialType,
@@ -111,10 +110,10 @@ class AndroidOwnerStorage constructor(
       val accountName = accountManagerFuture.result.getString(AccountManager.KEY_ACCOUNT_NAME)
       if (accountName == null) {
         callback.onError(AuthenticationCanceledException())
-        throw AuthenticationCanceledException()
+      } else {
+        callback.onResult(Account(accountName,
+          accountManagerFuture.result.getString(AccountManager.KEY_ACCOUNT_TYPE)))
       }
-      callback.onResult(Account(accountName,
-        accountManagerFuture.result.getString(AccountManager.KEY_ACCOUNT_TYPE)))
     }
   }
 

--- a/retroauth/src/main/java/com/andretietz/retroauth/OwnerStorage.kt
+++ b/retroauth/src/main/java/com/andretietz/retroauth/OwnerStorage.kt
@@ -25,17 +25,14 @@ interface OwnerStorage<in OWNER_TYPE : Any, OWNER : Any, in CREDENTIAL_TYPE : An
 
   /**
    * Creates an [OWNER] of a specific [ownerType] for a specific [credentialType]. So open a login and let the user
-   * login. If the User cancels the login an [AuthenticationCanceledException] should be thrown.
+   * login. If the User cancels, [Callback.onError] should be called with an [AuthenticationCanceledException].
    *
    * @param ownerType Type of owner you want to create.
    * @param credentialType Type of credential you want to open the login for.
    * @param callback Optional callback to get notified when the user was created `true` or not `false`.
    *
    * @return [OWNER] which was created.
-   *
-   * @throws AuthenticationCanceledException
    */
-  @Throws(AuthenticationCanceledException::class)
   fun createOwner(
     ownerType: OWNER_TYPE,
     credentialType: CREDENTIAL_TYPE,

--- a/retroauth/src/main/java/com/andretietz/retroauth/OwnerStorage.kt
+++ b/retroauth/src/main/java/com/andretietz/retroauth/OwnerStorage.kt
@@ -25,7 +25,8 @@ interface OwnerStorage<in OWNER_TYPE : Any, OWNER : Any, in CREDENTIAL_TYPE : An
 
   /**
    * Creates an [OWNER] of a specific [ownerType] for a specific [credentialType]. So open a login and let the user
-   * login. If the User cancels, [Callback.onError] should be called with an [AuthenticationCanceledException].
+   * login. If the User cancels, [Callback.onError] should be called with an [AuthenticationCanceledException] or if
+   * the [Future.get] is used, it'll throw that Exception
    *
    * @param ownerType Type of owner you want to create.
    * @param credentialType Type of credential you want to open the login for.


### PR DESCRIPTION
Currently there is an issue when an account is created explicit (by calling `ownerManager.createOwner()`). If the user presses the back-button on the `com.andretietz.retroauth.demo.LoginActivity`, the app would crash.
While the documentation of `OwnerStorage.createOwner()` claims to throw an `AuthenticationCanceledException`, the actual exception is not propagated.

The method `onError()` from the given callback is called as expected, though.