### PR TITLE
Fixed: getOwners should return account of ownerType

### DIFF
--- a/retroauth-android/src/main/java/com/andretietz/retroauth/AndroidOwnerStorage.kt
+++ b/retroauth-android/src/main/java/com/andretietz/retroauth/AndroidOwnerStorage.kt
@@ -76,7 +76,7 @@ class AndroidOwnerStorage constructor(
     return null
   }
 
-  override fun getOwners(ownerType: String): List<Account> = accountManager.accounts.toList()
+  override fun getOwners(ownerType: String): List<Account> = accountManager.accounts.toList().filter { it.type == ownerType }
 
   override fun switchActiveOwner(ownerType: String, owner: Account?) {
     val preferences = application.getSharedPreferences(ownerType, Context.MODE_PRIVATE)

--- a/retroauth-android/src/main/java/com/andretietz/retroauth/AndroidOwnerStorage.kt
+++ b/retroauth-android/src/main/java/com/andretietz/retroauth/AndroidOwnerStorage.kt
@@ -76,7 +76,8 @@ class AndroidOwnerStorage constructor(
     return null
   }
 
-  override fun getOwners(ownerType: String): List<Account> = accountManager.accounts.toList().filter { it.type == ownerType }
+  override fun getOwners(ownerType: String): List<Account> = accountManager.accounts.toList()
+    .filter { it.type == ownerType }
 
   override fun switchActiveOwner(ownerType: String, owner: Account?) {
     val preferences = application.getSharedPreferences(ownerType, Context.MODE_PRIVATE)


### PR DESCRIPTION
As per OwnerStorage.kt interface, 
`fun getOwners(ownerType: OWNER_TYPE): List`
should return a list of [OWNER]s of the given type but in AndroidOwnerManager.kt, this function returns all accounts.