### PR TITLE
Make CredentialInterceptor public

### DIFF
--- a/retroauth-android/src/main/java/com/andretietz/retroauth/AndroidMethodCache.kt
+++ b/retroauth-android/src/main/java/com/andretietz/retroauth/AndroidMethodCache.kt
@@ -22,7 +22,7 @@ import android.util.SparseArray
  * Since [SparseArray] is on Android slightly faster, you can use this instead of the default implementation
  * [MethodCache.DefaultMethodCache]
  */
-internal class AndroidMethodCache : MethodCache<String, AndroidCredentialType> {
+class AndroidMethodCache : MethodCache<String, AndroidCredentialType> {
   private val cache = SparseArray<RequestType<String, AndroidCredentialType>>()
 
   override fun register(requestIdentifier: Int, type: RequestType<String, AndroidCredentialType>) {

--- a/retroauth/src/main/java/com/andretietz/retroauth/CredentialInterceptor.kt
+++ b/retroauth/src/main/java/com/andretietz/retroauth/CredentialInterceptor.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.locks.ReentrantLock
  * @param <OWNER> a type that represents the owner of a credential. Since there could be multiple users on one client.
  * @param <CREDENTIAL_TYPE> type of the credential that should be added to the request
  */
-internal class CredentialInterceptor<out OWNER_TYPE : Any, OWNER : Any, CREDENTIAL_TYPE : Any, CREDENTIAL : Any>(
+class CredentialInterceptor<out OWNER_TYPE : Any, OWNER : Any, CREDENTIAL_TYPE : Any, CREDENTIAL : Any>(
   private val authenticator: Authenticator<OWNER_TYPE, OWNER, CREDENTIAL_TYPE, CREDENTIAL>,
   private val ownerManager: OwnerStorage<OWNER_TYPE, OWNER, CREDENTIAL_TYPE>,
   private val credentialStorage: CredentialStorage<OWNER, CREDENTIAL_TYPE, CREDENTIAL>,


### PR DESCRIPTION
We can make CredentialInterceptor public. This will help to add this interceptor directly to the okhttp client.